### PR TITLE
Fix pyproject config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ if(COFFE_ENABLE_PYTHON)
     # need to use this annoying hack. Note that this does not guarantee that the
     # Python executable is the one from the venv, but at least it finds the one
     # compatible with all of the packages from the venv
+    if(NOT COFFE_PYTHON_MINOR_VERSION)
+      execute_process(
+        COMMAND python -c "import sys;print(sys.version_info.minor)"
+        OUTPUT_VARIABLE COFFE_PYTHON_MINOR_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
     find_package(
       Python "3.${COFFE_PYTHON_MINOR_VERSION}" EXACT
       COMPONENTS Interpreter Development.Module

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pip install conan
 Then, generate a profile:
 
 ```sh
-conan profile detect
+conan profile detect --force
 ```
 
 Finally, install all of the dependencies in the `_build` directory:
@@ -132,6 +132,12 @@ If you would additionally like to install all of the various tools for testing, 
 
 ```sh
 pip install '.[all]'
+```
+
+**NOTE**: if using Conan to install some of the dependencies, you will need to specify the toolchain file using:
+
+```sh
+pip install '.[all]' --config-settings=cmake.define.CMAKE_TOOLCHAIN_FILE="_build/conan_toolchain.cmake"
 ```
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "coffe"
 dynamic = ["version"]
 description = "Python wrapper for the COrrelation Function Full-sky Estimator code"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 authors = [
     {name = "Goran Jelic-Cizmek", email = "goran.jelic-cizmek@unige.ch"},
 ]
@@ -63,6 +63,7 @@ test-command = ["python -c 'import coffe'", "pytest -vvv -k test_power_spectrum 
 [tool.cibuildwheel.macos]
 before-all = [
     # install CUBA, FFTW, GSL, libconfig, and CLASS
+    "python -m pip install conan",
     "conan profile detect --force",
     "conan install . --output-folder=_build --build=missing",
     "bash scripts/install_other.sh cuba class",
@@ -82,11 +83,6 @@ environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 [build-system]
 requires = [
     "scikit-build-core", "cython<3", "setuptools-scm>=8.0.0",
-    # why do we need Conan only on Darwin (i.e. MacOS)?
-    # because GSL, FFTW, etc. installed via `brew` always have the
-    # deployment target equal to the one of the build machine,
-    # while Linux does not care about this
-    "conan; sys_platform=='darwin'"
 ]
 build-backend = "scikit_build_core.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,9 @@ verbose = true
 version = ">=3.15.0"
 
 [tool.scikit-build.cmake.define]
-# on MacOS, this probably doesn't work;
-# to make a wheel, just use `cibuildwheel --platform macos`
 COFFE_ENABLE_CLASS = "ON"
 COFFE_ENABLE_PYTHON = "ON"
 COFFE_ENABLE_MATHOPTS = "ON"
-COFFE_ENABLE_CUBA="ON"
+COFFE_ENABLE_CUBA = "ON"
 
 [tool.setuptools_scm]

--- a/python/coffe/coffe.pxd
+++ b/python/coffe/coffe.pxd
@@ -9,13 +9,11 @@
 
 cdef extern from "<gsl/gsl_errno.h>":
 
-    cdef struct gsl_error_handler_t:
-        pass
+    ctypedef void (*gsl_error_handler_t) (const char* reason, const char* file, int line, int gsl_errno)
 
-    cdef gsl_error_handler_t *gsl_set_error_handler_off()
+    gsl_error_handler_t* gsl_set_error_handler(gsl_error_handler_t* new_handler)
 
-    cdef void gsl_set_error_handler(gsl_error_handler_t *)
-
+    gsl_error_handler_t* gsl_set_error_handler_off()
 
 cdef extern from "<gsl/gsl_spline.h>":
 


### PR DESCRIPTION
* Python 3.13 is still not out so max supported version is 3.12
* due to `before-all` and `before-build` being run _before_ any of the `build-system.requires` packages are installed, conan is now explicitly installed via pip on MacOS
* fix strange build issue on Linux (had to do with the declaration of functions in Cython)